### PR TITLE
Attempt to remove unnecessary parentheses

### DIFF
--- a/pytexit/core/core.py
+++ b/pytexit/core/core.py
@@ -126,6 +126,7 @@ class LatexVisitor(ast.NodeVisitor):
                         "Not": 800,
                         "USub": 800,
                         "Num": 1000,
+                        "Constant": 1000,
                         "Assign": 300,
                         "Sub": 300,
                         "Add": 300,
@@ -410,10 +411,11 @@ class LatexVisitor(ast.NodeVisitor):
         return self.prec(n.op)
 
     def visit_BinOp(self, n):
+    
         if self.prec(n.op) > self.prec(n.left):
             left = self.parenthesis(self.visit(n.left))
         elif isinstance(n.op, ast.Pow) and self.prec(n.op) == self.prec(n.left):
-            # Special case for power, which needs parantheses when combined to the left
+            # Special case for power, which needs parentheses when combined to the left
             left = self.parenthesis(self.visit(n.left))
         else:
             left = self.visit(n.left)
@@ -421,7 +423,7 @@ class LatexVisitor(ast.NodeVisitor):
             right = self.parenthesis(self.visit(n.right))
         else:
             right = self.visit(n.right)
-
+ 
         # Special binary operators
         if isinstance(n.op, ast.Div):
             if self.simplify_fractions:
@@ -462,7 +464,7 @@ class LatexVisitor(ast.NodeVisitor):
                 operator = r'\times'
             else: # get standard Mult operator (see visit_Mult)
                 operator = self.visit(n.op)
-                    
+
             if self.simplify_multipliers:
                 
                 # We simplify in some cases, for instance: a*2 -> 2a

--- a/pytexit/core/core.py
+++ b/pytexit/core/core.py
@@ -659,7 +659,10 @@ def simplify(s):
     # TRied with re.findall(r'\(\([^\(^\)]*(\([^\(^\)]+\))*[^\(^\)]*\)\)', s)  but
     # it doesnt work. One should better try to look for inner pairs and remove that
     # one after one..
-
+    
+    # Replace '\left(NUMBER\right)' with 'NUMBER'
+    # ------------
+    s = re.sub(r"\\left\(([\d\.]+)\\right\)", r"\1", s)
 
     # Improve readability:
 

--- a/pytexit/test/test_functions.py
+++ b/pytexit/test/test_functions.py
@@ -129,7 +129,7 @@ def test_hardcoded_names(verbose=True, **kwargs):
     assert py2tex('arcsinh(x)', print_latex=False) == '$$\sinh^{-1}(x)$$'
     assert py2tex('arccosh(x)', print_latex=False) == '$$\\cosh^{-1}(x)$$'
     
-    assert py2tex('np.power(2, 10)', print_latex=False) == '$${\\left(2\\right)}^{ 10}$$'
+    assert py2tex('np.power(2, 10)', print_latex=False) == '$${2}^{ 10}$$'
     # Additional function (conventions)
     assert py2tex('kron(i, j)', print_latex=False) == '$$\\delta_{i, j}$$'
     # unknown function:


### PR DESCRIPTION
I noticed that this lib adds a lot of unnecessary parentheses. This should at least remove some of them around simple and literal numbers.

Test script:
```python
from pytexit import py2tex
result = py2tex('9999 == Q_cu*1000 + Q_HE*1000')
```

Before:
```latex
$$9999=Q_{cu} \left(1000\right)+Q_{HE} \left(1000\right)$$
```

After:
```latex
$$9999=Q_{cu} 1000+Q_{HE} 1000$$
```

This is not a complete solution, but it definetly makes more complex formulas a lot mreo readable!