### PR TITLE
Problem with unary opeation not

### DIFF
--- a/pytexit/core/core.py
+++ b/pytexit/core/core.py
@@ -588,7 +588,7 @@ class LatexVisitor(ast.NodeVisitor):
         return self.operator("invert")
 
     def visit_Not(self, n):
-        return "\\neg"
+        return "\\neg "
 
     def visit_UAdd(self, n):
         return "+"


### PR DESCRIPTION
'not x' gives '\negx' instead of '\neg x'
I'm not sure if this is the best solution to debug this problem? At least it seems to work!
This bug was introduced in the function visit_UnaryOp(self, n) when removing the space between {0} and {1}... so that 10**-3 yields $$10^{-3}$$ and not $$10^{- 3}$$