### PR TITLE
Reworking simplify_output

### DIFF
--- a/pytexit/core/__init__.py
+++ b/pytexit/core/__init__.py
@@ -3,6 +3,6 @@
 
 """
 
-from .core import LatexVisitor, clean, simplify, uprint
+from .core import LatexVisitor, simplify, uprint
 from .docx import WordVisitor
 from .fortran import for2py

--- a/pytexit/pytexit.py
+++ b/pytexit/pytexit.py
@@ -12,11 +12,11 @@ import sys
 import six
 
 try:
-    from pytexit.core.core import LatexVisitor, preprocessing, simplify, uprint
+    from pytexit.core.core import LatexVisitor, preprocessing, simplify, uprint, replace_scientific
     from pytexit.core.docx import WordVisitor
     from pytexit.core.fortran import for2py
 except:  # if run locally as a script
-    from core.core import LatexVisitor, preprocessing, simplify, uprint
+    from core.core import LatexVisitor, preprocessing, simplify, uprint, replace_scientific
     from core.docx import WordVisitor
     from core.fortran import for2py
 try:
@@ -77,7 +77,7 @@ def py2tex(
     simplify_output: boolean
         if ``True``, simplify output. Ex::
 
-            1x10^-5 --> 10^-5.
+            1x10^-5 --> 10^-5
 
         See :func:`~pytexit.core.core.simplify` for more information.
         Default ``True``
@@ -85,7 +85,7 @@ def py2tex(
     simplify_ints: boolean
         if ``True``, simplify integers (useful for Python 2 expressions). Ex::
 
-            1. --> 1.
+            1. --> 1
 
         See :class:`~pytexit.core.core.LatexVisitor` for more information.
         Default ``True``
@@ -93,7 +93,7 @@ def py2tex(
     simplify_fractions: boolean
         if ``True``, simplify common fractions.  Ex::
 
-            0.5 --> 1/2.
+            0.5 --> 1/2
 
         See :class:`~pytexit.core.core.LatexVisitor` for more information.
         Default ``False``
@@ -147,7 +147,12 @@ def py2tex(
     except AssertionError:
         raise ValueError("Input must be a string")
 
-    expr = preprocessing(expr)  # removes unicode, module calls, etc.
+    expr = preprocessing(expr, simplify_output)  # removes unicode, module calls, etc.
+
+    # replace scientific notation with power of 10 (this needs to be done in
+    # preprocessing since the ast parser will replace 1e3 with 1000.0)
+    if simplify_output:
+        expr = replace_scientific(expr)
 
     # Parse
     pt = ast.parse(expr)
@@ -184,7 +189,7 @@ def py2tex(
 
     # Simplify if asked for
     if simplify_output:
-        s = simplify(s, tex_multiplier)
+        s = simplify(s)
 
     if output == "tex":
         s = tex_enclosure + s + tex_enclosure

--- a/pytexit/test/test_fortran.py
+++ b/pytexit/test/test_fortran.py
@@ -29,7 +29,7 @@ def test_for2tex(verbose=True, *args, **kwargs):
             (r"2.8d-11 * exp(-(26500 - 0.5 * 1.97 * 11600 )/T_gas)"),
             simplify_output=True,
         )
-        == "$$2.8\\times10^{-11}e^{\\frac{-\\left(26500-0.5\\times"
+        == "$$2.8\\times{10}^{-11} e^{\\frac{-\\left(26500-0.5\\times"
         + "1.97\\times11600\\right)}{T_{gas}}}$$"
     )
 

--- a/pytexit/test/test_functions.py
+++ b/pytexit/test/test_functions.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import sys
 
-from pytexit import py2tex, simplify, uprint
+from pytexit import py2tex, uprint
 
 
 def test_py2tex(verbose=True, **kwargs):
@@ -177,13 +177,6 @@ def test_hardcoded_names(verbose=True, **kwargs):
     assert py2tex("eps*lbd+Lbd", print_latex=False) == "$$\\epsilon \\lambda+\\Lambda$$"
 
 
-def test_simplify(verbose=True, **kwargs):
-    """ Post-processing simplifications """
-
-    assert simplify("1e-20*11e2") == r"10^{-20}*11\times10^2"
-    assert simplify("1e-20*11e-20+5+2") == r"10^{-20}*11\times10^{-20}+5+2"
-
-
 def test_simplify_parser(verbose=True, **kwargs):
     """Test simplifications during Parsing.
 
@@ -215,13 +208,22 @@ def test_simplify_parser(verbose=True, **kwargs):
         == "$$a\\times-2$$"
     )
 
+    # Test simplify_output
+    assert py2tex("2e7", simplify_output=True) == "$$2\\times{10}^7$$"
+    assert py2tex("2e7", simplify_output=False) == "$$20000000$$"
+    assert py2tex("1e7", simplify_output=True) == "$${10}^7$$"
+    assert py2tex("1e7", simplify_output=False) == "$$10000000$$"
+    assert py2tex("2e-7", simplify_output=True) == "$$2\\times{10}^{-7}$$"
+    assert py2tex("2e-7", simplify_output=False) == "$$2e-07$$"
+    assert py2tex("1e-7", simplify_output=True) == "$${10}^{-7}$$"
+    assert py2tex("1e-7", simplify_output=False) == "$$1e-07$$"
+
 
 def run_all_tests(verbose=True, **kwargs):
 
     test_py2tex(verbose=verbose, **kwargs)
     test_py2tex_py3only(verbose=verbose, **kwargs)
     test_hardcoded_names(verbose=verbose, **kwargs)
-    test_simplify(verbose=verbose, **kwargs)
     test_simplify_parser(verbose=verbose, **kwargs)
 
     return True


### PR DESCRIPTION
Keep scientific notation (powers of 10) for integers
Moved replacement from postprocessing to before ast parsing
Replaced tests for simplify_output