### PR TITLE
Add auto-deployment to PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,13 +20,13 @@ jobs:
         - pip install pre-commit
       script:
         - pre-commit run --all-files
-after_success:
-  # code coverage :
-  - pip install codecov
-  - codecov
-  
 deploy:
   provider: pypi
   username: <username>
   password: <encrypted password>
   edge: true
+after_test:
+  - ps: |
+      pip install wheel
+      python setup.py bdist_wheel
+      Get-ChildItem dist\*.whl | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,3 +24,9 @@ after_success:
   # code coverage :
   - pip install codecov
   - codecov
+  
+deploy:
+  provider: pypi
+  username: <username>
+  password: <encrypted password>
+  edge: true


### PR DESCRIPTION
We have added the requested feature to auto-deploy to PyPI by making the following changes
When the master branch is updated:
- We added the "deploy" attribute to the .travis.yml to add automatic deployment to PyPI
- We added the "after-test" attribute to .travis.yml to invoke the automatically deployment when all tests successfully pass
- We implement the creation of a new version number within the "after-test" deployment to PyPI, which was a requested feature