### PR TITLE
Issue #59 Nested subtraction order of operations

### DIFF
--- a/pytexit/core/core.py
+++ b/pytexit/core/core.py
@@ -102,15 +102,15 @@ class LatexVisitor(ast.NodeVisitor):
     """
 
     def __init__(
-        self,
-        dummy_var,
-        upperscript,
-        lowerscript,
-        verbose,
-        simplify_multipliers,
-        simplify_fractions,
-        simplify_ints,
-        tex_multiplier,
+            self,
+            dummy_var,
+            upperscript,
+            lowerscript,
+            verbose,
+            simplify_multipliers,
+            simplify_fractions,
+            simplify_ints,
+            tex_multiplier,
     ):
 
         super(LatexVisitor, self).__init__()
@@ -451,7 +451,7 @@ class LatexVisitor(ast.NodeVisitor):
     def visit_UnaryOp(self, n):
         # Note: Unary operator followed by a power needs no parenthesis
         if self.prec(n.op) > self.prec(n.operand) and not (
-            hasattr(n.operand, "op") and isinstance(n.operand.op, ast.Pow)
+                hasattr(n.operand, "op") and isinstance(n.operand.op, ast.Pow)
         ):
             return r"{0}{1}".format(
                 self.visit(n.op), self.parenthesis(self.visit(n.operand))
@@ -552,6 +552,7 @@ class LatexVisitor(ast.NodeVisitor):
             # TODO: Adjust so that parentheses are not added to the outermost op?
             # Sub BinOp requires explicit order of operations if it is nested as operand of
             # other BinOps. Therefore, Sub as operands are encased in parentheses.
+            # This is a hotfix, check Pull Request #60.
             return r"({0}{1}{2})".format(left, self.visit(n.op), right)
         else:
             return r"{0}{1}{2}".format(left, self.visit(n.op), right)
@@ -735,6 +736,7 @@ def simplify(s):
     # Any Sub() subexpression nested within the whole expression, if it is the first op of its nest layer, is encased
     # in parentheses. That's why all '(VARIABLE - VARIABLE)', where VARIABLE can be any alphanumeric substring, are
     # replaced with 'VARIABLE - VARIABLE' unless '(VARIABLE - VARIABLE)' is not a right operand of an op other than +.
+    # This is a hotfix, check Pull Request #60.
     s = re.sub(r"([^-/*]|^)\(((?:[a-zA-z]+|[0-9]+.[0-9]*)-(?:[a-zA-z]+|[0-9]+\.*[0-9]*))\)", r"\1\2", s)
 
     # Remove unecessary parenthesis?

--- a/pytexit/core/core.py
+++ b/pytexit/core/core.py
@@ -102,15 +102,15 @@ class LatexVisitor(ast.NodeVisitor):
     """
 
     def __init__(
-            self,
-            dummy_var,
-            upperscript,
-            lowerscript,
-            verbose,
-            simplify_multipliers,
-            simplify_fractions,
-            simplify_ints,
-            tex_multiplier,
+        self,
+        dummy_var,
+        upperscript,
+        lowerscript,
+        verbose,
+        simplify_multipliers,
+        simplify_fractions,
+        simplify_ints,
+        tex_multiplier,
     ):
 
         super(LatexVisitor, self).__init__()
@@ -451,7 +451,7 @@ class LatexVisitor(ast.NodeVisitor):
     def visit_UnaryOp(self, n):
         # Note: Unary operator followed by a power needs no parenthesis
         if self.prec(n.op) > self.prec(n.operand) and not (
-                hasattr(n.operand, "op") and isinstance(n.operand.op, ast.Pow)
+            hasattr(n.operand, "op") and isinstance(n.operand.op, ast.Pow)
         ):
             return r"{0}{1}".format(
                 self.visit(n.op), self.parenthesis(self.visit(n.operand))
@@ -552,7 +552,7 @@ class LatexVisitor(ast.NodeVisitor):
             # TODO: Adjust so that parentheses are not added to the outermost op?
             # Sub BinOp requires explicit order of operations if it is nested as operand of
             # other BinOps. Therefore, Sub as operands are encased in parentheses.
-            # This is a hotfix, check Pull Request #60.
+            # This is a hotfix, check Pull Request #60 for why it was implemented.
             return r"({0}{1}{2})".format(left, self.visit(n.op), right)
         else:
             return r"{0}{1}{2}".format(left, self.visit(n.op), right)
@@ -736,7 +736,7 @@ def simplify(s):
     # Any Sub() subexpression nested within the whole expression, if it is the first op of its nest layer, is encased
     # in parentheses. That's why all '(VARIABLE - VARIABLE)', where VARIABLE can be any alphanumeric substring, are
     # replaced with 'VARIABLE - VARIABLE' unless '(VARIABLE - VARIABLE)' is not a right operand of an op other than +.
-    # This is a hotfix, check Pull Request #60.
+    # This is a hotfix, check Pull Request #60 for why it was implemented.
     s = re.sub(r"([^-/*]|^)\(((?:[a-zA-z]+|[0-9]+.[0-9]*)-(?:[a-zA-z]+|[0-9]+\.*[0-9]*))\)", r"\1\2", s)
 
     # Remove unecessary parenthesis?

--- a/pytexit/pytexit.py
+++ b/pytexit/pytexit.py
@@ -193,12 +193,8 @@ def py2tex(
         )
     else:
         raise ValueError("Unexpected output: {0}".format(output))
-    if isinstance(pt.body[0], ast.Expr):
-        # To deal with cases such as 'x=something'
-        # TODO : one single command to start the visit?
-        s = Visitor.visit(pt.body[0].value)
-    else:  # For Compare / Assign expressions
-        s = Visitor.visit(pt.body[0])
+    # TODO : one single command to start the visit?
+    s = Visitor.visit(pt.body[0].value if isinstance(pt.body[0], ast.Expr) else pt.body[0])
 
     # Simplify if asked for
     if simplify_output:


### PR DESCRIPTION
Hi,
Issue #59 shows that nested subtraction operations have their parentheses removed, which results in the output being a different formula.

I added a special condition for nested subtractions, encasing them in parentheses in `visit_BinOp()`.

This process adds some redundant parentheses, which I removed by two regex substitutions in `simplify()`. They still don't remove outermost parentheses, so I added a TODO for that.