### PR TITLE
github actions

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,33 @@
+name: Publish Python 🐍 distributions 📦 to PyPI
+
+on: push
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.7"
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+    - name: Publish distribution 📦 to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PUSH_TO_PYPI }}

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,0 +1,35 @@
+name: Publish Python 🐍 distributions 📦 to TestPyPI
+
+on: push
+
+jobs:
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦  TestPyPI
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python 3.7
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.7"
+    - name: Install pypa/build
+      run: >-
+        python -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: >-
+        python -m
+        build
+        --sdist
+        --wheel
+        --outdir dist/
+        .
+    - name: Publish distribution 📦 to Test PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PUSH_TO_TESTPYPI }}
+        repository_url: https://test.pypi.org/legacy/
+


### PR DESCRIPTION
I have created a folder with GitHub actions. In the folder I put two actions. One to upload the new tagged version of the repo to TestPyPi and another one is for PyPi.

Only one thing is needed on your side is.
Create Secret Token in your repository
1. login to https://pypi.org
2. go to account settings /n <img width="216" alt="image" src="https://user-images.githubusercontent.com/29989124/194669701-e59b075c-8f4e-4ca5-8977-0ab0eb02f7f0.png">
3. scroll down until you find API Token
4. Add API token
5. Follow instructions

Copy the token and go to your GitHub profile 
add token as secret
<img width="363" alt="image" src="https://user-images.githubusercontent.com/29989124/194670084-d2191be8-ac1a-49e2-9499-c72afcc1ee9a.png">
in "Settings" -> "Secrets" -> "Actions" of the repository you are setting this up.

in GitHub workflow files I called secrets as "PUSH_TO_TESTPYPI" and "PUSH_TO_PYPI"

<img width="598" alt="image" src="https://user-images.githubusercontent.com/29989124/195217481-33543b37-ce78-49a8-9558-e69f99d1a827.png">

