### PR TITLE
Support for "÷" symbol, two options

### DIFF
--- a/pytexit/core/core.py
+++ b/pytexit/core/core.py
@@ -17,6 +17,7 @@ unicode_tbl = {
     "β": "beta",
     "χ": "chi",
     "δ": "delta",
+    "÷": "/",
     "ε": "epsilon",
     "γ": "gamma",
     "ψ": "psi",
@@ -301,7 +302,7 @@ class LatexVisitor(ast.NodeVisitor):
         """Special features:
         - Recognize underscripts in identifiers names (default: underscore)
         - Recognize upperscripts in identifiers names (default: ˆ, valid in Python3)
-        Note that using ˆ is not recommanded in variable names because it may
+        Note that using ˆ is not recommended in variable names because it may
         be confused with the operator ^, but in some special cases of extensively
         long formulas with lots of indices, it may help the readability of the
         code

--- a/pytexit/test/test_functions.py
+++ b/pytexit/test/test_functions.py
@@ -49,7 +49,7 @@ def test_py2tex(verbose=True, **kwargs):
         r"$$-x^2$$",
         r"$$-\left(x^2+y^2\right)$$",
         r"$$-\left(x+y\right)^2$$",
-        r"$$\frac{\frac{3}{4}}{\frac{8}{15}}$$",
+        r"$$\frac{3}{4}\div\frac{8}{15}$$",
     ]
 
     for i, expr in enumerate(expr_py):

--- a/pytexit/test/test_functions.py
+++ b/pytexit/test/test_functions.py
@@ -32,6 +32,7 @@ def test_py2tex(verbose=True, **kwargs):
         r"-x**2",
         r"-(x**2+y**2)",
         r"-(x+y)**2",
+        r"(3/4)" + "÷" + "(8/15)",
     ]
 
     expr_tex = [
@@ -48,6 +49,7 @@ def test_py2tex(verbose=True, **kwargs):
         r"$$-x^2$$",
         r"$$-\left(x^2+y^2\right)$$",
         r"$$-\left(x+y\right)^2$$",
+        r"$$\frac{\frac{3}{4}}{\frac{8}{15}}$$",
     ]
 
     for i, expr in enumerate(expr_py):


### PR DESCRIPTION
In first commit, "÷" is converted to "/" in the unicode table so that it can be correctly parsed. Also added a test case in test_functions.py to confirm.

Fixed minor typo in docstring for visit_name()

Second commit, "÷" is converted to a magic number in the unicode table so that it can be correctly parsed. It is then returned as "\div" using some custom logic on traversal. Also added a test case in test_functions.py to confirm.